### PR TITLE
:gear: Bump environment lock file for cmake-re v0.0.77

### DIFF
--- a/environments/linux.container.lock
+++ b/environments/linux.container.lock
@@ -1,2 +1,2 @@
 // Generated File DO NOT MANUALLY EDIT, this file SHOULD be commited to version control system
-{"image_base_name":"tipibuild/tipi-ubuntu","manifest_digest":"sha256:00ee385cc1d31389a30a502f072d11d0af4c3af3781e83c9a26d13f3032746ce","platform":"linux/amd64","raw_envzip_hash":"dacd2fa9f3c31ddfb088d46e0557db9305df7997"}
+{"image_base_name":"tipibuild/tipi-ubuntu","manifest_digest":"sha256:43829f3c6ebcc6638e02c1054b5d03fd3d200cbfe858c82fa5158d83ea640780","platform":"linux/amd64","raw_envzip_hash":"f31fea98d2ff13b5be66675b718df17ef98daf20"}


### PR DESCRIPTION
This stores an environment lock files which matches the released one